### PR TITLE
[2.10.5] Added embeds_one functionality

### DIFF
--- a/app/models/concerns/terrier/embedded.rb
+++ b/app/models/concerns/terrier/embedded.rb
@@ -232,10 +232,20 @@ module Terrier::Embedded
       {}
     end
 
-    def embeds_many(model_name_plural, options={})
-      attr_accessor model_name_plural
-      options[:type] = model_name_plural.to_s.singularize.classify.constantize
-      field_defs[model_name_plural] = EmbeddedFieldDef.new(options)
+    def embeds_one(model_name, options={})
+      self._embed(model_name, options)
+    end
+
+    def embeds_many(model_name, options={})
+      self._embed(model_name, options)
+    end
+
+    private
+
+    def _embed(model_name, options)
+      attr_accessor model_name
+      options[:type] = model_name.to_s.classify.constantize
+      field_defs[model_name] = EmbeddedFieldDef.new(options)
     end
 
   end

--- a/app/models/concerns/terrier/embedder.rb
+++ b/app/models/concerns/terrier/embedder.rb
@@ -19,7 +19,7 @@ module Terrier::Embedder
 
     def embeds_one(model_name, options={})
 
-      model = (options[:class_name] || model_name.to_s.classify).constantize
+      model = options[:class] || (options[:class_name] || model_name.to_s.classify).constantize
       field_name = model_name.to_s
 
       embedded_fields[model_name] = {

--- a/app/models/concerns/terrier/embedder.rb
+++ b/app/models/concerns/terrier/embedder.rb
@@ -18,6 +18,7 @@ module Terrier::Embedder
     end
 
     def embeds_one(model_name, options={})
+
       model = (options[:class_name] || model_name.to_s.classify).constantize
       field_name = model_name.to_s
 
@@ -52,25 +53,10 @@ module Terrier::Embedder
         super val
       end
 
-      model.fields.each do |embeded_field_name, _|
-        define_method(embeded_field_name) do
-          if (embeded_obj = self.send(field_name)).is_a? model
-            embeded_obj.send(embeded_field_name)
-          else
-            nil
-          end
-        end
-        define_method("#{embeded_field_name}=") do |val|
-          if self.send(field_name).blank?
-            self.send("#{field_name}=", model.new(embeded_field_name => val))
-          else
-            self.send(field_name).send("#{embeded_field_name}=", val)
-          end
-        end
-      end
     end
 
     def embeds_many(model_name, options={})
+
       model = (options[:class_name] || model_name.to_s.classify).constantize
       field_name = model_name.to_s
 
@@ -121,7 +107,9 @@ module Terrier::Embedder
       define_method("#{field_name}_array=") { |array| self.send "#{field_name}=", array }
       define_method("#{model_name}_json") { self.send(model_name).to_json }
       define_method("#{model_name}_json=") { |json| self.send("#{model_name}=", JSON.parse(json)) }
+
     end
+
   end
 
 end

--- a/app/models/concerns/terrier/embedder.rb
+++ b/app/models/concerns/terrier/embedder.rb
@@ -57,7 +57,7 @@ module Terrier::Embedder
 
     def embeds_many(model_name, options={})
 
-      model = (options[:class_name] || model_name.to_s.classify).constantize
+      model = options[:class] || (options[:class_name] || model_name.to_s.classify).constantize
       field_name = model_name.to_s
 
       embedded_fields[model_name] = {

--- a/app/models/concerns/terrier/embedder.rb
+++ b/app/models/concerns/terrier/embedder.rb
@@ -33,7 +33,7 @@ module Terrier::Embedder
           val = val.length>0 ? JSON.parse(val) : nil
         end
         if val.blank?
-          nil # may want to have this return a new, but empty instance of the embeded model?
+          nil
         elsif val.is_a? String
           model.from_string(val)
         else

--- a/lib/terrier/version.rb
+++ b/lib/terrier/version.rb
@@ -1,3 +1,3 @@
 module Terrier
-  VERSION = '2.10.4'
+  VERSION = '2.10.5'
 end


### PR DESCRIPTION
Works in a similar way to embeds_many, but shortcuts to allow the embedded object's fields to be accessed directly from embedder.

For instance, if `Foo` embeds `Bar` and `Bar` has the field `baz`, you can call `foo_instance.baz` and `foo_instance.baz=` directly.
Maintains `foo_instance.bar` and `foo_instance.bar=` similarly to embeds many.
From the above example, if `foo_instance.bar` is undefined and `foo_instance.baz=5` is called, a new instance of `Bar` will be created for `foo_instance`, but only the `bar` attribute will be set.