### PR TITLE
Production servers use model cache from executor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    terrier-engine (2.20.2)
+    terrier-engine (2.20.3)
       amazing_print
       dotenv
       loofah (>= 2.3.1)

--- a/app/controllers/concerns/terrier/script_crud.rb
+++ b/app/controllers/concerns/terrier/script_crud.rb
@@ -17,7 +17,6 @@ module Terrier::ScriptCrud
             field_type_options: ScriptField.field_type_options,
             fields_help: Terrier::ScriptConfig.fields_help,
             month_groups: ScheduleRule.month_groups,
-            hours: ScheduleRule.hours,
             days: ScheduleRule.days,
             weeks: ScheduleRule.weeks
           }

--- a/app/models/schedule_rule.rb
+++ b/app/models/schedule_rule.rb
@@ -82,7 +82,7 @@ class ScheduleRule
   @weeks = %w(1 2 3 4 5 every_2 all)
 
   class << self
-    attr_accessor :days, :short_days, :months, :short_months, :month_groups, :quarter_january, :quarter_february, :quarter_march, :weeks, :hours
+    attr_accessor :days, :short_days, :months, :short_months, :month_groups, :quarter_january, :quarter_february, :quarter_march, :weeks
   end
 
 

--- a/lib/tasks/terrier/scripts.rake
+++ b/lib/tasks/terrier/scripts.rake
@@ -11,7 +11,7 @@ namespace :scripts do
     scripts.each do |script|
       if script.schedule_contains_day? day
         puts "Running script #{script.id}: #{script.title}"
-        executor = ScriptExecutor.new script
+        executor = ScriptExecutor.new script, ModelCache.new
         executor.me = "#{time.titleize} Runner"
         run = executor.init_run
         executor.run run, nil

--- a/lib/terrier/version.rb
+++ b/lib/terrier/version.rb
@@ -1,3 +1,3 @@
 module Terrier
-  VERSION = '2.20.2'
+  VERSION = '2.20.3'
 end


### PR DESCRIPTION
This was initially removed because it caused errors when attempting to run scripts locally in the terrier-engine project. Apparently, some scheduled scripts use it instead of initializing their own ModelCache: [https://3.basecamp.com/4458222/buckets/18430459/todos/5827340331](https://3.basecamp.com/4458222/buckets/18430459/todos/5827340331)
Additionally, the errors this caused locally no longer occur in my testing.

I've also removed some unused code from run_hourly_scripts.