### PR TITLE
Platform styling improvements

### DIFF
--- a/app/assets/stylesheets/terrier/tt-panel.scss
+++ b/app/assets/stylesheets/terrier/tt-panel.scss
@@ -4,11 +4,12 @@
 	border-radius: var(--tt-border-radius);
 	background: var(--tt-panel-background);
 	@include tt-box-shadow;
+
+	gap: var(--tt-gap);
 	.panel-header {
 		display: flex;
 		align-items: center;
 		gap: var(--tt-gap);
-		padding: var(--tt-pad);
 		h1, h2, h3, h4, h5 {
 			margin: 0;
 			display: flex;
@@ -28,15 +29,11 @@
 		&.gap {
 			gap: var(--tt-gap);
 		}
-		&.padded {
-			padding: var(--tt-pad);
-		}
 	}
 	.panel-actions {
 		display: flex;
 		align-items: center;
 		.primary-actions, .secondary-actions {
-			padding: var(--tt-pad);
 			gap: var(--tt-gap);
 			display: flex;
 			align-items: center;
@@ -49,7 +46,7 @@
 			justify-content: right;
 		}
 	}
-	&.padded .panel-content {
+	&.padded {
 		// .padded panel implies padded content
 		padding: var(--tt-pad);
 	}

--- a/app/frontend/terrier/fragments.ts
+++ b/app/frontend/terrier/fragments.ts
@@ -170,7 +170,7 @@ class LabeledValueFragment<TT extends ThemeType> extends ContentFragment<TT> {
 
     private _value?: string
     private _valueIcon?: TT['icons']
-    private _valueIconColor?: TT['colors']
+    private _valueIconColor?: TT['colors'] | null
     private _valueClass?: string[]
 
     private _href?: string
@@ -180,7 +180,7 @@ class LabeledValueFragment<TT extends ThemeType> extends ContentFragment<TT> {
 
     private _tooltip?: string
 
-    value(value: string, icon?: TT['icons'], iconColor?: TT['colors']) {
+    value(value: string, icon?: TT['icons'], iconColor?: TT['colors'] | null) {
         this._value = value
         this._valueIcon = icon
         this._valueIconColor = iconColor
@@ -236,7 +236,8 @@ class LabeledValueFragment<TT extends ThemeType> extends ContentFragment<TT> {
                 if (this._tooltip) valueBox.dataAttr("tooltip", this._tooltip)
                 if (this._value) {
                     if (this._valueIcon) {
-                        this.theme.renderIcon(valueBox, this._valueIcon, this._valueIconColor ?? 'link')
+                        const color = (this._valueIconColor === undefined) ? 'link' : this._valueIconColor
+                        this.theme.renderIcon(valueBox, this._valueIcon, color)
                     }
                     valueBox.div('.value-text', {text: this._value})
                 }
@@ -331,14 +332,11 @@ function labeledList<TT extends ThemeType>(theme: Theme<TT>) {
 
 /**
  * Create a new button in the parent.
- * @param parent
- * @param title
- * @param icon
  */
-function button<TT extends ThemeType>(parent: PartTag, theme: Theme<TT>, title: string, icon?: TT['icons']) {
+function button<TT extends ThemeType>(parent: PartTag, theme: Theme<TT>, title: string, icon?: TT['icons'], iconColor: TT['colors'] | null = null) {
     return parent.a('.tt-button', button => {
         if (icon) {
-            theme.renderIcon(button, icon, 'white')
+            theme.renderIcon(button, icon, iconColor)
         }
         button.div('.title', {text: title})
     })
@@ -347,15 +345,11 @@ function button<TT extends ThemeType>(parent: PartTag, theme: Theme<TT>, title: 
 /**
  * Create a new simple value display in the parent.
  * This is just some text with an optional icon that doesn't have a separate label.
- * @param parent
- * @param title
- * @param icon
- * @param iconColor
  */
-function simpleValue<TT extends ThemeType>(parent: PartTag, theme: Theme<TT>, title: string, icon?: TT['icons'], iconColor?: TT['colors']) {
+function simpleValue<TT extends ThemeType>(parent: PartTag, theme: Theme<TT>, title: string, icon?: TT['icons'], iconColor: TT['colors'] | null = 'link') {
     return parent.div('.tt-simple-value.shrink', button => {
         if (icon) {
-            theme.renderIcon(button, icon, iconColor || 'link')
+            theme.renderIcon(button, icon, iconColor)
         }
         button.div('.title', {text: title})
     })

--- a/app/frontend/terrier/theme.ts
+++ b/app/frontend/terrier/theme.ts
@@ -32,15 +32,15 @@ export type Action<TT extends ThemeType> = {
  * Options to pass to `render` that control how the actions are displayed.
  */
 export type RenderActionOptions<TT extends ThemeType> = {
-    iconColor?: TT['colors']
+    iconColor?: TT['colors'] | null
     badgeColor?: TT['colors']
     defaultClass?: string
 }
 
 export default abstract class Theme<TT extends ThemeType> {
-    abstract renderIcon(parent: PartTag, icon: TT['icons'], color?: TT['colors']): void
+    abstract renderIcon(parent: PartTag, icon: TT['icons'], color?: TT['colors'] | null): void
 
-    abstract renderCloseIcon(parent: PartTag, color?: TT['colors']): void
+    abstract renderCloseIcon(parent: PartTag, color?: TT['colors'] | null): void
 
     abstract colorValue(name: TT['colors']): string
 

--- a/app/frontend/terrier/toasts.ts
+++ b/app/frontend/terrier/toasts.ts
@@ -33,7 +33,7 @@ function show<TT extends ThemeType>(message: string, options: ToastOptions<TT>, 
         parent.class('tt-toast')
         parent.class(options.color)
         if (options?.icon) {
-            theme.renderIcon(parent, options.icon, 'white')
+            theme.renderIcon(parent, options.icon, null)
         }
         parent.span('.text', {text: message})
     })

--- a/lib/tasks/npm.rake
+++ b/lib/tasks/npm.rake
@@ -1,16 +1,16 @@
 namespace :npm do
 
-  desc "Publish the terrier-engine npm package"
-  task publish: :environment do
-    dir = './tmp/dist'
+  DIST_DIR = './tmp/dist'
 
+  desc "Build the distribution artifacts"
+  task build: :environment do
     # clear the directory
-    if Dir.exist? dir
-      puts "Clearing dist directory #{dir.bold}"
-      FileUtils.rm_rf("#{dir}/.", secure: true)
+    if Dir.exist? DIST_DIR
+      puts "Clearing dist directory #{DIST_DIR.bold}"
+      FileUtils.rm_rf("#{DIST_DIR}/.", secure: true)
     else
-      puts "Creating dist directory #{dir.bold}"
-      FileUtils.mkdir_p dir
+      puts "Creating dist directory #{DIST_DIR.bold}"
+      FileUtils.mkdir_p DIST_DIR
     end
 
     # overwrite the package version
@@ -23,15 +23,18 @@ namespace :npm do
 
     # copy package.json
     puts "Copying #{'package.json'.bold}"
-    FileUtils.cp pkg_in, "#{dir}/package.json"
+    FileUtils.cp pkg_in, "#{DIST_DIR}/package.json"
 
     # copy the contents of the directory
     from_dir = "app/frontend/terrier/"
     puts "Copying all files in #{from_dir.blue}"
-    FileUtils.cp_r "#{from_dir}.", dir
+    FileUtils.cp_r "#{from_dir}.", DIST_DIR
+  end
 
+  desc "Publish the terrier-engine npm package"
+  task publish: :build do
     # publish the package
-    cmd = "npm publish #{dir}"
+    cmd = "npm publish #{DIST_DIR}"
     puts "Publishing package with #{cmd.italic}"
     exec cmd
   end

--- a/test/dummy/app/frontend/demo/demo-theme.ts
+++ b/test/dummy/app/frontend/demo/demo-theme.ts
@@ -20,7 +20,7 @@ export default class DemoTheme extends Theme<DemoThemeType> {
         return name;
     }
 
-    renderIcon(parent: PartTag, icon: DemoThemeType['icons'], color: ColorName | undefined) {
+    renderIcon(parent: PartTag, icon: DemoThemeType['icons'], color?: ColorName | null) {
         const classes: string[] = [icon]
         if (color?.length) {
             classes.push(color)
@@ -32,7 +32,7 @@ export default class DemoTheme extends Theme<DemoThemeType> {
         return "";
     }
 
-    renderCloseIcon(parent: PartTag, _color: DemoThemeType["colors"] | undefined): void {
+    renderCloseIcon(parent: PartTag, _color?: DemoThemeType["colors"] | null): void {
         // we don't have icons, just render an times
         parent.i('.glyp-close.close')
     }


### PR DESCRIPTION
3 things:

- Task for building the package separately from publishing.
- Allow passing `null` as the icon color which indicates that the icon should be the same color as the surrounding text, rather than a specific theme color. This helps with button icons in dark mode in hub
- Use flex gap to separate panel header/content/actions instead of padding.