### PR TITLE
Change compound field styling to work better with checkbox/radio or other stuff that won't fill the full width/height

### DIFF
--- a/app/assets/stylesheets/terrier/tt-forms.scss
+++ b/app/assets/stylesheets/terrier/tt-forms.scss
@@ -25,7 +25,8 @@
 	// checkboxes and radio buttons
 	input[type=checkbox], input[type=radio] {
 		margin: 0;
-		transform: scale(1.5);
+		width: 1.5em;
+		height: 1.5em;
 		cursor: pointer;
 	}
 
@@ -64,13 +65,15 @@
 
 .tt-compound-field {
 	@include tt-rounded-corners;
+	@include tt-concave-bg(#{var(--tt-field-background)}, false);
 	display: flex;
 	align-items: stretch;
 
-	// use a 1px padding and gap to emulate a border
-	padding: 1px;
-	gap: 1px;
-	background-color: var(--tt-field-border-color);
+	border: 1px solid var(--tt-field-border-color);
+
+	> *:not(:last-child) {
+		border-right: 1px solid var(--tt-field-border-color);
+	}
 
 	&.inline {
 		display: inline-flex;
@@ -97,6 +100,11 @@
 		&:last-child {
 			@include tt-right-rounded-corners;
 		}
+	}
+
+	input[type=checkbox], input[type=radio] {
+		align-self: center;
+		margin: 0 14px; // can't use padding on checkbox/radio, but we need space. so margin
 	}
 
 	ul {
@@ -130,7 +138,6 @@
 	}
 
 	label {
-		@include tt-concave-bg(#{var(--tt-field-background)}, false);
 		text-transform: none;
 	}
 


### PR DESCRIPTION
Should be essentially equivalent for everything that's not a checkbox or radio. Basically just want to check that this won't screw anything up in data dive

before:
![CleanShot 2023-09-22 at 11 55 55@2x](https://github.com/Terrier-Tech/terrier-engine/assets/1226888/f01ca851-0dad-4c9a-aa64-d25fb7ee561c)

after:
![CleanShot 2023-09-22 at 11 56 46@2x](https://github.com/Terrier-Tech/terrier-engine/assets/1226888/48a7eec6-a429-4d64-9817-c35ebf1c3b94)
