### PR TITLE
change overflow to auto

### DIFF
--- a/app/assets/stylesheets/terrier/tiny-modal.scss
+++ b/app/assets/stylesheets/terrier/tiny-modal.scss
@@ -120,7 +120,7 @@ body.with-modal {
 	.modal-content {
 		min-height: 400px;
 		flex: 1 1 auto;
-		overflow-y: scroll;
+		overflow-y: auto;
 	}
 	.modal-actions {
 		flex: 0 0 auto;


### PR DESCRIPTION
The css in terrier-engine is giving all the modals in app a scrollbar to the right:
![CleanShot 2023-10-11 at 11 36 14](https://github.com/Terrier-Tech/terrier-engine/assets/104331754/bfbba79b-76c6-4e76-9c38-84e94dacd1d4)
After change:
![CleanShot 2023-10-11 at 11 36 43](https://github.com/Terrier-Tech/terrier-engine/assets/104331754/cbb68a0d-c6a9-4c3c-9bd8-4414b38da55e)
