### PR TITLE
Exclude columns from frontend

### DIFF
--- a/app/models/concerns/terrier/model.rb
+++ b/app/models/concerns/terrier/model.rb
@@ -279,6 +279,15 @@ module Terrier::Model
       @_exclude_from_frontend
     end
 
+    def exclude_columns_from_frontend!(*args)
+      @_exclude_columns_from_frontend ||= Set.new
+      @_exclude_columns_from_frontend.merge(args.map(&:to_s))
+    end
+
+    def exclude_columns_from_frontend
+      @_exclude_columns_from_frontend
+    end
+
 
     ## Upserting (Class Methods)
 

--- a/lib/terrier/frontend/base_generator.rb
+++ b/lib/terrier/frontend/base_generator.rb
@@ -70,7 +70,7 @@ class BaseGenerator
   # Uses Prettier to format a file
   # @param path [String] the absolute path to the file
   def prettier_file(path)
-    cmd = "npx --no-install prettier --write --no-semi #{path}"
+    cmd = "npx --no-install prettier --print-width 200 --write --no-semi #{path}"
     info "Formatting file with #{cmd.bold}"
     system cmd
   end

--- a/lib/terrier/frontend/model_generator.rb
+++ b/lib/terrier/frontend/model_generator.rb
@@ -43,8 +43,9 @@ class ModelGenerator < BaseGenerator
         end
       end
       attachments = @has_shrine ? model.ancestors.grep(Shrine::Attachment).map(&:attachment_name) : []
+      columns_to_exclude = model.try(:exclude_columns_from_frontend) || Set.new
       models[model.name] = {
-        columns: model.columns,
+        columns: model.columns.reject { |c| c.name.in?(columns_to_exclude) },
         reflections: model.reflections,
         belongs_tos: model.reflections.select { |_, ref| model.column_names.include?("#{ref.name}_id") },
         has_manies: model.reflections.select { |_, ref| ref.class_name.classify.constantize.column_names.include?("#{model.model_name.singular}_id") },


### PR DESCRIPTION
Adds the ability to exclude specific columns from generated frontend model types. This can be useful in the case of deprecated columns or conflicts between column names and relations