### PR TITLE
Event Trackable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    terrier-engine (4.20.0)
+    terrier-engine (4.21.0)
       amazing_print
       coderay
       colorize

--- a/app/models/concerns/terrier/event_trackable.rb
+++ b/app/models/concerns/terrier/event_trackable.rb
@@ -1,0 +1,60 @@
+# Provides a thread safe way to track created models within a block.
+#
+#   class User
+#     include EventTrackable
+#   end
+#
+#   User.track_events do
+#     User.new(name: "Alice").save!
+#   end
+#   => [<User name="Alice"...>]
+#
+module EventTrackable
+  extend ActiveSupport::Concern
+
+  included do
+    after_create :track_event, if: -> { self.class.tracking? }
+    thread_mattr_accessor :tracked, instance_accessor: false, default: nil
+  end
+
+  class_methods do
+    # @return [Array<ActiveRecord::Base>] tracked models
+    def track_events
+      last_tracked = self.tracked
+      self.tracked = []
+      yield
+      self.tracked
+    ensure
+      unless last_tracked.nil?
+        last_tracked += self.tracked
+      end
+      self.tracked = last_tracked
+    end
+
+    def tracking?
+      !self.tracked.nil?
+    end
+  end
+
+  class << self
+    # Provides a way to visualize tracked models in pretty table format. Assumes all models are the same.
+    # @param tracked [Array<ActiveRecord::Base>] models
+    # @param keys [Array<Symbol>] attributes to display
+    # @return [String] pretty table
+    def tracked_to_s(tracked, *keys)
+      Terminal::Table.new do |table|
+        table.title = "Tracked Events"
+        table.headings = keys.map { _1.to_s.titleize }
+        tracked.each do |event|
+          table.add_row keys.map { event.send _1 }
+        end
+      end.to_s
+    end
+  end
+
+  private
+
+  def track_event
+    self.class.tracked << self
+  end
+end

--- a/app/models/concerns/terrier/event_trackable.rb
+++ b/app/models/concerns/terrier/event_trackable.rb
@@ -9,7 +9,7 @@
 #   end
 #   => [<User name="Alice"...>]
 #
-module EventTrackable
+module Terrier::EventTrackable
   extend ActiveSupport::Concern
 
   included do

--- a/lib/terrier/version.rb
+++ b/lib/terrier/version.rb
@@ -1,3 +1,3 @@
 module Terrier
-  VERSION = '4.20.0'
+  VERSION = '4.21.0'
 end

--- a/test/dummy/app/models/application_record.rb
+++ b/test/dummy/app/models/application_record.rb
@@ -21,6 +21,7 @@ class ApplicationRecord < ActiveRecord::Base
     self.updated_by_name = user
     self.save!
   end
+  alias save_by! save_by_user!
 
   def save_if_needed!(change_user)
     return false unless self.changed?

--- a/test/models/concerns/event_trackable_test.rb
+++ b/test/models/concerns/event_trackable_test.rb
@@ -18,7 +18,7 @@ class EventTrackableTest < ActiveSupport::TestCase
   end
 
   class MockModel < ApplicationRecord
-    include EventTrackable
+    include Terrier::EventTrackable
   end
 
   # @return [Tempfile]
@@ -170,7 +170,7 @@ class EventTrackableTest < ActiveSupport::TestCase
       MockModel.new(name: "Name 2").save_by! "System"
     end
 
-    actual = EventTrackable.tracked_to_s(tracked, :name, :created_by_name)
+    actual = Terrier::EventTrackable.tracked_to_s(tracked, :name, :created_by_name)
 
     expected = <<~STR.strip
       +--------------------------+

--- a/test/models/concerns/event_trackable_test.rb
+++ b/test/models/concerns/event_trackable_test.rb
@@ -1,0 +1,187 @@
+require "test_helper"
+require_relative "../../../app/models/concerns/terrier/event_trackable"
+
+class EventTrackableTest < ActiveSupport::TestCase
+
+  def setup
+    create_mock_model_table
+  end
+
+  def create_mock_model_table
+    ActiveRecord::Migration.suppress_messages do
+      ActiveRecord::Schema.define do
+        create_model :mock_models do |table|
+          table.text :name, default: "Name"
+        end
+      end
+    end
+  end
+
+  class MockModel < ApplicationRecord
+    include EventTrackable
+  end
+
+  # @return [Tempfile]
+  def prepare_txt_file(file_name, content:)
+    file = Tempfile.new file_name
+    file.write content
+    file.rewind
+    file
+  end
+
+  test "returns [] when no events are tracked" do
+    assert_equal([], MockModel.track_events {})
+  end
+
+  test "resets tracked events after tracking is done" do
+    MockModel.track_events { MockModel.new.save_by! }
+    assert_equal([], MockModel.track_events {})
+  end
+
+  test "resets tracked events if an error is raised" do
+    begin
+      MockModel.track_events do
+        MockModel.new.save_by!
+        raise "Error"
+      end
+    rescue
+      # continue
+    end
+    assert_equal([], MockModel.track_events {})
+  end
+
+  test "does not track events before tracking is called" do
+    MockModel.new.save_by!
+    assert_equal([], MockModel.track_events {})
+  end
+
+  test "does not track events after tracking is called" do
+    tracked = MockModel.track_events {}
+    MockModel.new.save_by!
+    assert_equal [], tracked
+  end
+
+  test "tracks single create event" do
+    model = nil
+    tracked = MockModel.track_events do
+      model = MockModel.new
+      model.save_by!
+    end
+    assert_equal [model], tracked
+  end
+
+  test "tracks multiple create events" do
+    models = nil
+    tracked = MockModel.track_events do
+      models = [MockModel.new, MockModel.new]
+      models.each(&:save_by!)
+    end
+    assert_equal models, tracked
+  end
+
+  test "does not track update events" do
+    model = MockModel.new
+    model.save_by!
+    tracked = MockModel.track_events do
+      model.name = "New Name"
+      model.save_by!
+    end
+    assert_equal [], tracked
+  end
+
+  test "allows for nested tracking calls" do
+    level_1, level_2, level_3 = [], [], []
+    tracked_2, tracked_3 = nil
+
+    tracked_1 = MockModel.track_events do # level 1
+      model = MockModel.new
+      model.save_by!
+      level_1 << model
+      tracked_2 = MockModel.track_events do # level 2
+        model = MockModel.new
+        model.save_by!
+        [level_1, level_2].each { _1 << model }
+        tracked_3 = MockModel.track_events do # level 3
+          model = MockModel.new
+          model.save_by!
+          [level_1, level_2, level_3].each { _1 << model }
+        end
+      end
+    end
+
+    assert_equal [level_1, level_2, level_3], [tracked_1, tracked_2, tracked_3]
+  end
+
+  test "tracks events over multiple threads separately" do
+    tracked_1, tracked_2, model_1, model_2 = nil
+
+    thread_1 = Thread.new do
+      tracked_1 = MockModel.track_events do
+        model_1 = MockModel.new
+        model_1.save_by!
+        sleep 0.1 # ensure second thread can start
+      end
+    end
+    thread_2 = Thread.new do
+      tracked_2 = MockModel.track_events do
+        model_2 = MockModel.new
+        model_2.save_by!
+      end
+    end
+
+    thread_1.join
+    thread_2.join
+
+    assert_equal [[model_1], [model_2]], [tracked_1, tracked_2]
+  end
+
+  test "tracks events over multiple io bound threads separately" do
+    file_1 = prepare_txt_file "name_1.txt", content: "Name 1 " * 100_000
+    file_2 = prepare_txt_file "name_2.txt", content: "Name 2 " * 100_000
+
+    tracked_1, tracked_2, model_1, model_2 = nil
+
+    thread_1 = Thread.new do
+      tracked_1 = MockModel.track_events do
+        model_1 = MockModel.new(name: File.read(file_1.path))
+        model_1.save_by!
+        sleep 0.1 # ensure second thread can start
+      end
+    end
+    thread_2 = Thread.new do
+      tracked_2 = MockModel.track_events do
+        model_2 = MockModel.new(name: File.read(file_2.path))
+        model_2.save_by!
+      end
+    end
+
+    thread_1.join
+    thread_2.join
+
+    assert_equal [[model_1], [model_2]], [tracked_1, tracked_2]
+  ensure
+    [file_1, file_2].each(&:close)
+    [file_1, file_2].each(&:unlink)
+  end
+
+  test "returns tracked table string" do
+    tracked = MockModel.track_events do
+      MockModel.new(name: "Name 1").save_by! "System"
+      MockModel.new(name: "Name 2").save_by! "System"
+    end
+
+    actual = EventTrackable.tracked_to_s(tracked, :name, :created_by_name)
+
+    expected = <<~STR.strip
+      +--------------------------+
+      |      Tracked Events      |
+      +--------+-----------------+
+      | Name   | Created By Name |
+      +--------+-----------------+
+      | Name 1 | System          |
+      | Name 2 | System          |
+      +--------+-----------------+
+    STR
+    assert_equal expected, actual
+  end
+end


### PR DESCRIPTION
A way to capture create events for a model inside a block. This will be useful for jobs since we can track action logs created for that specific job.