### PR TITLE
Event Trackable: Remove Print Helper

### DIFF
--- a/app/models/concerns/terrier/event_trackable.rb
+++ b/app/models/concerns/terrier/event_trackable.rb
@@ -36,22 +36,6 @@ module Terrier::EventTrackable
     end
   end
 
-  class << self
-    # Provides a way to visualize tracked models in pretty table format. Assumes all models are the same.
-    # @param tracked [Array<ActiveRecord::Base>] models
-    # @param keys [Array<Symbol>] attributes to display
-    # @return [String] pretty table
-    def tracked_to_s(tracked, *keys)
-      Terminal::Table.new do |table|
-        table.title = "Tracked Events"
-        table.headings = keys.map { _1.to_s.titleize }
-        tracked.each do |event|
-          table.add_row keys.map { event.send _1 }
-        end
-      end.to_s
-    end
-  end
-
   private
 
   def track_event

--- a/test/models/concerns/event_trackable_test.rb
+++ b/test/models/concerns/event_trackable_test.rb
@@ -174,25 +174,4 @@ class EventTrackableTest < ActiveSupport::TestCase
     [file_1, file_2].each(&:close)
     [file_1, file_2].each(&:unlink)
   end
-
-  test "returns tracked table string" do
-    tracked = MockModel.track_events do
-      MockModel.new(name: "Name 1").save_by! "System"
-      MockModel.new(name: "Name 2").save_by! "System"
-    end
-
-    actual = Terrier::EventTrackable.tracked_to_s(tracked, :name, :created_by_name)
-
-    expected = <<~STR.strip
-      +--------------------------+
-      |      Tracked Events      |
-      +--------+-----------------+
-      | Name   | Created By Name |
-      +--------+-----------------+
-      | Name 1 | System          |
-      | Name 2 | System          |
-      +--------+-----------------+
-    STR
-    assert_equal expected, actual
-  end
 end


### PR DESCRIPTION
This isn't actually all that useful and is easily replaced by amazing print.