### PR TITLE
Custom select field part

### DIFF
--- a/app/assets/stylesheets/terrier/tt-select-field.scss
+++ b/app/assets/stylesheets/terrier/tt-select-field.scss
@@ -23,39 +23,46 @@
 	}
 }
 
-.tt-select-options-dropdown {
+.tt-select-options-dropdown-container {
 	.tt-dropdown-content {
 		transition: none;
 		@include scroll-y;
-		padding: 4px;
-		font-weight: bold;
-		background-color: rgba(50, 50, 50, .75);
-		backdrop-filter: blur(10px);
-		div {
-			padding: 2px 4px 2px 32px;
+		margin: 4px 0px;
+		background: none;
+		box-shadow: none;
+		height: calc(100vh - 8px);
+		.tt-select-options-dropdown {
+			font-weight: bold;
+			background-color: rgba(50, 50, 50, .75);
+			backdrop-filter: blur(10px);
 			border-radius: 4px;
-			cursor: default;
-			@include single-line;
-			&.tt-select-options-group-header {
-				color: #ccc;
-				padding-left: 16px;
-			}
-			&:not(.tt-select-options-group-header) {
-				&.hover, &:hover {
-					background-color: #5288e9;
+			padding: 4px;
+			div {
+				padding: 2px 4px 2px 32px;
+				border-radius: 4px;
+				cursor: default;
+				@include single-line;
+				&.tt-select-options-group-header {
+					color: #ccc;
+					padding-left: 16px;
 				}
-				height: 28px;
+				&:not(.tt-select-options-group-header) {
+					&.hover, &:hover {
+						background-color: #f1940f; // darker primary color
+					}
+					height: 28px;
+				}
+				&.selected::before {
+					@include glyps-font;
+					content: $glyp-checkmark;
+					position: absolute;
+					left: 8px;
+				}
 			}
-			&.selected::before {
-				@include glyps-font;
-				content: $glyp-checkmark;
-				position: absolute;
-				left: 8px;
-			}
-		}
-		&:has(.tt-select-options-group-header) {
-			div:not(.tt-select-options-group-header) {
-				padding-left: 32px;
+			&:has(.tt-select-options-group-header) {
+				div:not(.tt-select-options-group-header) {
+					padding-left: 32px;
+				}
 			}
 		}
 	}

--- a/app/assets/stylesheets/terrier/tt-select-field.scss
+++ b/app/assets/stylesheets/terrier/tt-select-field.scss
@@ -1,0 +1,62 @@
+@import 'tt-mixins';
+@import 'scripts';
+@import 'glyps-meta';
+
+.tt-select-field {
+	border: 1px solid #ddd;
+	border-radius: 4px;
+	transition: background-color 0.2s ease;
+	padding: 0.5em 1.6em 0.5em 0.5em;
+	background-color: #fff;
+	font-size: 16px;
+	height: 40px;
+	min-width: 145px;
+	@include single-line;
+	display: flex;
+	align-items: center;
+	background-image: url(data:image/svg+xml;base64,PHN2ZyBmaWxsPSdibGFjaycgaGVpZ2h0PScyNCcgdmlld0JveD0nMCAwIDI0IDI0JyB3aWR0aD0nMjQnIHhtbG5zPSdodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2Zyc+PHBhdGggZD0nTTcgMTBsNSA1IDUtNXonLz48cGF0aCBkPSdNMCAwaDI0djI0SDB6JyBmaWxsPSdub25lJy8+PC9zdmc+);
+	background-repeat: no-repeat;
+	background-position-x: right;
+	background-position-y: 8px;
+	div {
+		cursor: default;
+	}
+}
+
+.tt-select-options-dropdown {
+	.tt-dropdown-content {
+		transition: none;
+		@include scroll-y;
+		padding: 4px;
+		font-weight: bold;
+		background-color: rgba(50, 50, 50, .75);
+		backdrop-filter: blur(10px);
+		div {
+			padding: 2px 4px 2px 32px;
+			border-radius: 4px;
+			cursor: default;
+			@include single-line;
+			&.tt-select-options-group-header {
+				color: #ccc;
+				padding-left: 16px;
+			}
+			&:not(.tt-select-options-group-header) {
+				&.hover, &:hover {
+					background-color: #5288e9;
+				}
+				height: 28px;
+			}
+			&.selected::before {
+				@include glyps-font;
+				content: $glyp-checkmark;
+				position: absolute;
+				left: 8px;
+			}
+		}
+		&:has(.tt-select-options-group-header) {
+			div:not(.tt-select-options-group-header) {
+				padding-left: 32px;
+			}
+		}
+	}
+}

--- a/app/frontend/terrier/overlays.ts
+++ b/app/frontend/terrier/overlays.ts
@@ -156,7 +156,7 @@ class OverlayLayer<PartType extends Part<StateType>, StateType extends {}> exten
 // Anchoring
 ////////////////////////////////////////////////////////////////////////////////
 
-type AnchorResult = {
+export type AnchorResult = {
     left: number
     top: number
     width?: number,
@@ -337,7 +337,6 @@ function centerElement(elem: HTMLElement) {
     elem.setAttribute('style', styleString)
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // Export
 ////////////////////////////////////////////////////////////////////////////////
@@ -345,6 +344,9 @@ function centerElement(elem: HTMLElement) {
 const Overlays = {
     anchorElement,
     centerElement,
+    getWindowSize,
+    getElementSize,
+    clampAnchorResult,
     anchorBox
 }
 

--- a/app/frontend/terrier/parts/content-part.ts
+++ b/app/frontend/terrier/parts/content-part.ts
@@ -1,6 +1,5 @@
 import {Action, IconName} from "../theme"
-import {PartParent, PartTag} from "tuff-core/parts"
-import {Dropdown} from "../dropdowns"
+import {PartTag} from "tuff-core/parts"
 import TerrierPart from "./terrier-part"
 
 export type PanelActions = {
@@ -138,49 +137,4 @@ export default abstract class ContentPart<TState> extends TerrierPart<TState> {
     hasActions(level: ActionLevel): boolean {
         return this._actions[level].length > 0
     }
-
-
-    /// Dropdowns
-
-    /**
-     * Shows the given dropdown part on the page.
-     * It's generally better to call `toggleDropdown` instead so that the dropdown will be
-     * hidden upon a subsequent click on the target.
-     * @param constructor a constructor for a dropdown part
-     * @param state the dropdown's state
-     * @param target the target element around which to show the dropdown
-     */
-    makeDropdown<DropdownType extends Dropdown<DropdownStateType>, DropdownStateType extends {}>(
-        constructor: { new(p: PartParent, id: string, state: DropdownStateType): DropdownType; },
-        state: DropdownStateType,
-        target: EventTarget | null) {
-        const dropdown = this.app.addOverlay(constructor, state, 'dropdown')
-        dropdown.parentPart = this
-        if (target && target instanceof HTMLElement) {
-            dropdown.anchor(target)
-            this.app.lastDropdownTarget = target
-        }
-    }
-
-    clearDropdowns() {
-        this.app.clearDropdowns()
-    }
-
-    /**
-     * Calls `makeDropdown` only if there's not a dropdown currently originating from the target.
-     * @param constructor a constructor for a dropdown part
-     * @param state the dropdown's state
-     * @param target the target element around which to show the dropdown
-     */
-    toggleDropdown<DropdownType extends Dropdown<DropdownStateType>, DropdownStateType extends {}>(
-        constructor: { new(p: PartParent, id: string, state: DropdownStateType): DropdownType; },
-        state: DropdownStateType,
-        target: EventTarget | null) {
-        if (target && target instanceof HTMLElement && target == this.app.lastDropdownTarget) {
-            this.clearDropdowns()
-        } else {
-            this.makeDropdown(constructor, state, target)
-        }
-    }
-
 }

--- a/app/frontend/terrier/parts/select-field-part.ts
+++ b/app/frontend/terrier/parts/select-field-part.ts
@@ -1,9 +1,9 @@
 import {SelectOption, SelectOptions} from "tuff-core/forms"
-import ContentPart from "./content-part"
 import Messages, { TypedKey } from "tuff-core/messages"
 import {PartTag} from "tuff-core/parts"
 import {Dropdown} from "../dropdowns"
 import Overlays, {AnchorResult} from "../overlays"
+import TerrierPart from "./terrier-part";
 
 /**
  * Replacement part for a 'select' field that retrieves its options from a centralized data source
@@ -19,7 +19,7 @@ export type SelectFieldState = {
     selected_option: SelectOption
 }
 
-export class SelectFieldPart<T extends SelectFieldState> extends ContentPart<T> {
+export class SelectFieldPart<T extends SelectFieldState> extends TerrierPart<T> {
     _toggleDropdownKey = Messages.untypedKey()
 
     selectedOptionKey = Messages.typedKey<{ selected_option: SelectOption }>()

--- a/app/frontend/terrier/parts/select-field-part.ts
+++ b/app/frontend/terrier/parts/select-field-part.ts
@@ -9,13 +9,12 @@ import TerrierPart from "./terrier-part";
  * Replacement part for a 'select' field that retrieves its options from a centralized data source
  * rather than appending them to the DOM. When there are multiple select fields on the same page
  * with the same set of options, this is more efficient than the standard 'select' field.
- * @param options the options to add
- * @param value the currently selected option value
- * @param select_key the
  */
 
 export type SelectFieldState = {
+    /** the options to add */
     options: SelectOptions
+    /** the currently selected option value */
     selected_option: SelectOption
 }
 
@@ -44,11 +43,10 @@ export class SelectFieldPart<T extends SelectFieldState> extends TerrierPart<T> 
     }
 
     onOptionSelected(selectedOption: SelectOption) {
-        this.state.selected_option = selectedOption
-        this.dirty()
+        this.assignState({ ...this.state, selected_option: selectedOption })
     }
 
-    renderContent(parent: PartTag) {
+    render(parent: PartTag) {
         parent.div({ text: this.state.selected_option.title })
         parent.emitClick(this._toggleDropdownKey)
     }
@@ -137,11 +135,7 @@ export class SelectOptionsDropdown extends Dropdown<SelectFieldDropdownState> {
         }
 
         // how far down the select options list we need to scroll
-        let scrollAmount = (selectOptionSize.height * (selectedOptionIndex))
-        const hasOptGroups = this.state.options.find((o) => 'group' in o)
-        if (hasOptGroups) {
-            scrollAmount -= selectOptionSize.height
-        }
+        let scrollAmount = selectedElement.offsetTop
 
         let scrollTop = scrollAmount - anchorRect.top
         let dropdownIsShrunk = false
@@ -158,7 +152,7 @@ export class SelectOptionsDropdown extends Dropdown<SelectFieldDropdownState> {
                 dropdownIsShrunk = true
             }
         } else {
-            if (hasOptGroups) {
+            if (this.state.options.find((o) => 'group' in o)) {
                 result.top += selectOptionSize.height
             }
         }

--- a/app/frontend/terrier/parts/select-field-part.ts
+++ b/app/frontend/terrier/parts/select-field-part.ts
@@ -1,0 +1,214 @@
+import {SelectOption, SelectOptions} from "tuff-core/forms"
+import ContentPart from "./content-part"
+import Messages, { TypedKey } from "tuff-core/messages"
+import {PartTag} from "tuff-core/parts"
+import {Dropdown} from "../dropdowns"
+import Overlays, {AnchorResult} from "../overlays"
+
+/**
+ * Replacement part for a 'select' field that retrieves its options from a centralized data source
+ * rather than appending them to the DOM. When there are multiple select fields on the same page
+ * with the same set of options, this is more efficient than the standard 'select' field.
+ * @param options the options to add
+ * @param value the currently selected option value
+ * @param select_key the
+ */
+
+export type SelectFieldState = {
+    options: SelectOptions
+    selected_option: SelectOption
+}
+
+export class SelectFieldPart<T extends SelectFieldState> extends ContentPart<T> {
+    _toggleDropdownKey = Messages.untypedKey()
+
+    selectedOptionKey = Messages.typedKey<{ selected_option: SelectOption }>()
+
+    async init() {
+        await super.init()
+        this.onClick(this._toggleDropdownKey, () => {
+            this.toggleDropdown(SelectOptionsDropdown, {
+                options: this.state.options,
+                selected_option: this.state.selected_option,
+                select_key: this.selectedOptionKey
+            }, this.element)
+        })
+        this.listenMessage(this.selectedOptionKey, m => {
+            console.log('heard option selected')
+            this.onOptionSelected(m.data.selected_option)
+        }, { attach: "passive" })
+    }
+
+    get parentClasses(): Array<string> {
+        return ['tt-select-field', ...super.parentClasses]
+    }
+
+    onOptionSelected(selectedOption: SelectOption) {
+        this.state.selected_option = selectedOption
+        this.dirty()
+    }
+
+    renderContent(parent: PartTag) {
+        parent.div({ text: this.state.selected_option.title })
+        parent.emitClick(this._toggleDropdownKey)
+    }
+}
+
+/**
+ * Dropdown part to accompany the centralized data select field
+ */
+
+export type SelectFieldDropdownState = SelectFieldState & {
+    select_key: TypedKey<{ selected_option: SelectOption }>
+}
+export class SelectOptionsDropdown extends Dropdown<SelectFieldDropdownState> {
+    _clickedOptionKey = Messages.typedKey<{ selected_option: SelectOption }>()
+
+    async init() {
+        await super.init()
+        this.onClick(this._clickedOptionKey, m => {
+            this.emitMessage(this.state.select_key, { selected_option: m.data.selected_option })
+            this.clear()
+        })
+    }
+    get autoClose(): boolean {
+        return true
+    }
+
+    get parentClasses(): Array<string> {
+        return ['tt-select-options-dropdown', ...super.parentClasses]
+    }
+
+    renderContent(parent: PartTag) {
+        for (const opt of this.state.options) {
+            if ('group' in opt) {
+                parent.div('.tt-select-options-group-header', { text: opt.group } )
+                for (const groupOpt of opt.options) {
+                    this.renderOption(parent, groupOpt)
+                }
+            } else {
+                this.renderOption(parent, opt)
+            }
+        }
+    }
+
+    renderOption(parent: PartTag, opt: SelectOption) {
+        parent.div({ text: opt.title }, option => {
+            if (this.state.selected_option.value == opt.value) option.class('selected')
+        }).emitClick(this._clickedOptionKey, { selected_option: opt })
+    }
+
+    update(elem: HTMLElement) {
+        const dropdown = elem.querySelector('.tt-dropdown-content') as HTMLElement
+        if (dropdown) {
+            const selectedElement = dropdown.querySelector('.selected') as HTMLElement
+            if (this.anchorTarget && selectedElement) {
+                this.anchorSelectDropdown(dropdown, this.anchorTarget, selectedElement)
+            }
+        }
+    }
+
+    /**
+     * Anchors a select dropdown on top of a select field. Uses the currently selected child option to determine positioning.
+     * Assumes that all child elements have the same height.
+     * @param dropdown the element to reposition
+     * @param selectField the anchor select field
+     * @param selectedElement the selected option that will be positioned directly above the select field
+     */
+    anchorSelectDropdown(dropdown: HTMLElement, selectField: HTMLElement, selectedElement: HTMLElement) {
+        const dropdownSize = Overlays.getElementSize(dropdown)
+        const selectOptionSize = Overlays.getElementSize(selectedElement)
+
+        const selectedOptionIndex = Array.prototype.indexOf.call(dropdown.childNodes, selectedElement)
+
+        const anchorRect = selectField.getBoundingClientRect()
+        const win = Overlays.getWindowSize()
+
+        const result: AnchorResult = {
+            top: anchorRect.y - (selectOptionSize.height * selectedOptionIndex),
+            left: anchorRect.x,
+            valid: true
+        }
+
+        Overlays.clampAnchorResult(result, dropdownSize, win)
+
+        if (dropdownSize.width < anchorRect.width) {
+            result.width = anchorRect.width
+        }
+
+        // how far down the select options list we need to scroll
+        let scrollAmount = (selectOptionSize.height * (selectedOptionIndex))
+        const hasOptGroups = this.state.options.find((o) => 'group' in o)
+        if (hasOptGroups) {
+            scrollAmount -= selectOptionSize.height
+        }
+
+        let scrollTop = scrollAmount - anchorRect.top
+        let dropdownIsShrunk = false
+
+        if (dropdownSize.height > win.height - anchorRect.top) { // attempting to fill the whole window height with the dropdown, so we may need to adjust placement of dropdown
+            if (scrollAmount < anchorRect.top) { // need space above the dropdown
+                result.top = anchorRect.top - scrollAmount
+                result.height = win.height - result.top
+                scrollTop = 0
+                dropdownIsShrunk = true
+            } else if (dropdownSize.height - scrollAmount < win.height) { // need space below the dropdown
+                result.height = dropdownSize.height - scrollAmount + anchorRect.top
+                scrollTop = scrollAmount
+                dropdownIsShrunk = true
+            }
+        } else {
+            if (hasOptGroups) {
+                result.top += selectOptionSize.height
+            }
+        }
+
+        let styleString = ""
+        for (const key of ['top', 'left', 'width', 'height'] as const) {
+            if (result[key] != null) {
+                styleString += `${key}: ${result[key]}px;`
+            }
+        }
+
+        dropdown.setAttribute('style', styleString)
+        dropdown.scrollTo({ top: scrollTop })
+
+        dropdown.classList.add('show')
+        selectedElement.classList.add('hover')
+        selectedElement.addEventListener('mouseleave', () => selectedElement.classList.remove('hover'))
+
+        // if the dropdown has been temporarily shrunk, increase the size as we scroll
+        if (dropdownIsShrunk) {
+            let currentHeight = dropdown.clientHeight
+            let currentScrollTop = dropdown.scrollTop
+            dropdown.addEventListener('scroll', _ => {
+                const newScrollTop = dropdown.scrollTop; // Get scroll position
+                const scrollDiff = currentScrollTop - newScrollTop
+
+                if (scrollDiff > 0) { // scrolling up
+                    // Calculate new height based on scroll amount
+                    const newHeight = Math.min(currentHeight + scrollDiff, window.innerHeight) // Don't exceed window height
+
+                    // Update the element's height
+                    dropdown.style.height = `${newHeight}px`
+
+                    currentHeight = newHeight
+                    currentScrollTop = newScrollTop
+                } else if (scrollDiff < 0) { // scrolling down
+                    // if there is space above the dropdown, also adjust the top
+                    const newHeight = Math.min(currentHeight - scrollDiff, window.innerHeight)
+                    dropdown.style.height = `${newHeight}px`
+
+                    const newTop = window.innerHeight - newHeight
+                    dropdown.style.top = `${newTop}px`
+
+                    if (newTop > 0) {
+                        dropdown.scrollTo({ top: currentScrollTop })
+                    }
+
+                    currentHeight = newHeight
+                }
+            })
+        }
+    }
+}

--- a/app/frontend/terrier/parts/select-field-part.ts
+++ b/app/frontend/terrier/parts/select-field-part.ts
@@ -25,6 +25,7 @@ export class SelectFieldPart<T extends SelectFieldState> extends TerrierPart<T> 
 
     async init() {
         await super.init()
+        this.state.selected_option = this.populateOptionIfBlank(this.state.selected_option)
         this.onClick(this._toggleDropdownKey, () => {
             this.toggleDropdown(SelectOptionsDropdown, {
                 options: this.state.options,
@@ -44,6 +45,30 @@ export class SelectFieldPart<T extends SelectFieldState> extends TerrierPart<T> 
 
     onOptionSelected(selectedOption: SelectOption) {
         this.assignState({ ...this.state, selected_option: selectedOption })
+    }
+
+    assignState(state: T) {
+        if (state == this.state) {
+            return false
+        }
+        this.state = state
+        this.state.selected_option = this.populateOptionIfBlank(this.state.selected_option)
+        this.dirty()
+        return true
+    }
+
+    populateOptionIfBlank(option: SelectOption) {
+        let newValue = option.value
+        let newTitle = option.title
+
+        if (option.value == '' && option.title === undefined) {
+            newValue = null
+            newTitle = ''
+        } else if (option.value == null && option.title === undefined) {
+            newValue = ''
+            newTitle = ''
+        }
+        return { title: newTitle, value: newValue }
     }
 
     render(parent: PartTag) {

--- a/app/frontend/terrier/parts/terrier-part.ts
+++ b/app/frontend/terrier/parts/terrier-part.ts
@@ -1,10 +1,11 @@
-import {Part, PartTag} from "tuff-core/parts"
+import {Part, PartParent, PartTag} from "tuff-core/parts"
 import {TerrierApp} from "../app"
 import Loading from "../loading"
 import Theme, {IconName} from "../theme"
 import Toasts, {ToastOptions} from "../toasts"
 import {DbErrors} from "../db-client"
 import * as inflection from "inflection"
+import {Dropdown} from "../dropdowns";
 
 /**
  * Base class for ALL parts in a Terrier application.
@@ -156,6 +157,50 @@ export default abstract class TerrierPart<TState> extends Part<TState> {
      */
     successToast(message: string, icon?: IconName) {
         this.showToast(message, {icon, color: 'success'})
+    }
+
+
+    /// Dropdowns
+
+    /**
+     * Shows the given dropdown part on the page.
+     * It's generally better to call `toggleDropdown` instead so that the dropdown will be
+     * hidden upon a subsequent click on the target.
+     * @param constructor a constructor for a dropdown part
+     * @param state the dropdown's state
+     * @param target the target element around which to show the dropdown
+     */
+    makeDropdown<DropdownType extends Dropdown<DropdownStateType>, DropdownStateType extends {}>(
+        constructor: { new(p: PartParent, id: string, state: DropdownStateType): DropdownType; },
+        state: DropdownStateType,
+        target: EventTarget | null) {
+        const dropdown = this.app.addOverlay(constructor, state, 'dropdown')
+        dropdown.parentPart = this
+        if (target && target instanceof HTMLElement) {
+            dropdown.anchor(target)
+            this.app.lastDropdownTarget = target
+        }
+    }
+
+    clearDropdowns() {
+        this.app.clearDropdowns()
+    }
+
+    /**
+     * Calls `makeDropdown` only if there's not a dropdown currently originating from the target.
+     * @param constructor a constructor for a dropdown part
+     * @param state the dropdown's state
+     * @param target the target element around which to show the dropdown
+     */
+    toggleDropdown<DropdownType extends Dropdown<DropdownStateType>, DropdownStateType extends {}>(
+        constructor: { new(p: PartParent, id: string, state: DropdownStateType): DropdownType; },
+        state: DropdownStateType,
+        target: EventTarget | null) {
+        if (target && target instanceof HTMLElement && target == this.app.lastDropdownTarget) {
+            this.clearDropdowns()
+        } else {
+            this.makeDropdown(constructor, state, target)
+        }
     }
 
 }


### PR DESCRIPTION
There are many select fields on the editor pages that all have the same list of select options, and some of these options lists are very long. If we continue to use the HTML select elements, a list of options must be appended to the DOM for each select field.

The solution here is to create a custom select field part that acts almost identically to the HTML element, but the list of options can come from a centralized data source. This way, we only need to store the list of options once. Here is how the new select options look on the commission rules editor page:

![CleanShot 2024-04-25 at 09 11 13](https://github.com/Terrier-Tech/terrier-engine/assets/104331754/b0f02866-7dae-4c28-8771-fcb004960974)

I think this belongs in terrier.tech because it may be useful in places other than these editor views.