### PR TITLE
Bug Fix: To Array Before Plucking

### DIFF
--- a/lib/terrier/scripts/script_searcher.rb
+++ b/lib/terrier/scripts/script_searcher.rb
@@ -11,7 +11,7 @@ class ScriptSearcher
     t = Time.now
     results = query.exec
     total= results.present? ? results.first['total'] : 0
-    ids= results.present? ? results.pluck('id') : []
+    ids = results.present? ? results.to_a.pluck('id') : []
     dt = Time.now - t
 
     OpenStruct.new({


### PR DESCRIPTION
`QueryResult` does not have a `#pluck` method