### PR TITLE
Bug Fix: Script Log Not Showing In Script Runs Modal

### DIFF
--- a/app/assets/javascripts/terrier/scripts.coffee
+++ b/app/assets/javascripts/terrier/scripts.coffee
@@ -1277,7 +1277,7 @@ _runsTemplate = tinyTemplate (runs) ->
 											a '.with-icon.clear-run', title: 'Clears the status of this run, allowing the script to be run again.', ->
 												icon '.glyp-cancelled.lyph-close'
 												span '', 'Clear'
-										else if run.log_file_name?.length
+										else if run.log_url?.length
 											a '.with-icon', href: run.log_url, target: '_blank', ->
 												icon '.glyp-items.lyph-list'
 												span '', 'Log'


### PR DESCRIPTION
This seemed to originate from Clypboard where `script_runs` had a `log_file_name` column. Instead of adding `log_file_name` to Lycensed & Terrier.tech `script_runs`, it makes more sense to make the presence of `log_url` the source of truth for a present log file.