### PR TITLE
Remove modal max-width

### DIFF
--- a/app/assets/javascripts/terrier/tiny-modal.coffee
+++ b/app/assets/javascripts/terrier/tiny-modal.coffee
@@ -116,9 +116,6 @@ _layoutRow = (row) ->
 	row.parents('#modal-window').css 'max-height', "#{maxHeight}px"
 	row.find('.modal-column').css 'max-height', "#{maxHeight}px"
 
-	# ensure that each column isn't wider than the window
-	row.children('.modal-column').css 'max-width', $('#modal-window').width()
-
 _actionPartial = (action) ->
 	sel = '.action'
 	if action.icon?.length


### PR DESCRIPTION
https://terrier.tech/hub/posts/fef47431-8030-4845-b097-61d25b822534

Before:
![CleanShot 2024-06-07 at 15 46 38](https://github.com/Terrier-Tech/terrier-engine/assets/25541844/6292dc5b-92ce-43b0-be0f-25a4b4b705ef)

After:
![CleanShot 2024-06-07 at 15 44 41](https://github.com/Terrier-Tech/terrier-engine/assets/25541844/507ab8c5-6854-480e-94f9-8e8a35c1d97d)

This line prevents modals from being resized past the modal window's original width when it loaded. It's allegedly here to prevent [a bug](https://github.com/Terrier-Tech/clypboard-server/commit/fcb25d79e63104ad816cbf1ffc6d35a9c2d1b10c) that was seen with the unit sweeps table, but I can't recreate the bug when I remove this line. 