### PR TITLE
make sure time zone factors into date field value calculation

### DIFF
--- a/lib/terrier/scripts/script_field.rb
+++ b/lib/terrier/scripts/script_field.rb
@@ -17,7 +17,7 @@ class ScriptField
     elsif s =~ /\d{4}-\d{2}-\d{2}/
       Time.parse s
     else
-      eval(s)
+      eval(s).to_time
     end
   end
 


### PR DESCRIPTION
https://terrier.tech/hub/posts/c5a8080d-8bb6-4ec3-b2c7-7c2d0fb14498

`eval` appears to be ignoring the time zone, which results in some cases where it's off by 1 day