### PR TITLE
Bugfix: Application Record Does Not Include Terrier::Model in Lycensed

### DIFF
--- a/app/models/dd_dive.rb
+++ b/app/models/dd_dive.rb
@@ -29,6 +29,7 @@
 # | Belongs To | updated_by    | User        |
 # +------------+---------------+-------------+
 class DdDive < ApplicationRecord
+  include Terrier::Model
 
   def self.metadata
     {

--- a/app/models/dd_dive_group.rb
+++ b/app/models/dd_dive_group.rb
@@ -22,6 +22,7 @@
 # | Belongs To | updated_by | User   |
 # +------------+------------+--------+
 class DdDiveGroup < ApplicationRecord
+  include Terrier::Model
 
   def self.metadata
     {

--- a/app/models/dd_dive_run.rb
+++ b/app/models/dd_dive_run.rb
@@ -23,6 +23,7 @@
 # | Belongs To | updated_by | User   |
 # +------------+------------+--------+
 class DdDiveRun < ApplicationRecord
+  include Terrier::Model
 
   def self.metadata
     {


### PR DESCRIPTION
While trying to update `terrier-engine` from `4.21.5` to `4.28.0` in Lycensed, `rake zeitwerk:ensure` raised an error. The `DbDiveX` models assume that `ApplicationRecord` has `Terrier::Engine` included (for `::emails_field`), which is not true in Lycensed. This is the quick fix, although I'm curious if there's a reason `Terrier::Model` is not used in Lycensed? We could add it, although I'm unsure of the consequences.

```
lycensed git:(update/terrier-engine) ✗ bundle exec rake "zeitwerk:ensure"
/Users/john/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/iguvium-0.9.3/lib/iguvium/cv.rb:4: warning: undefining the allocator of T_DATA class NArray
[ZeitWerk Ensure Task] INFO :: Eager-loading all files...
[Rake Task] INTERNAL :: Uncaught exception: [Zeitguard] FAILURE :: Eager Loader: Eager loading of constants failed: undefined method `emails_field' for DdDive:Class
/Users/john/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/activerecord-7.0.8/lib/active_record/dynamic_matchers.rb:22:in `method_missing'
/Users/john/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/bundler/gems/terrier-engine-199fbcc2dc30/app/models/dd_dive.rb:60:in `<class:DdDive>'
/Users/john/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/bundler/gems/terrier-engine-199fbcc2dc30/app/models/dd_dive.rb:31:in `<top (required)>'
/Users/john/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bootsnap-1.9.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
/Users/john/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bootsnap-1.9.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
/Users/john/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bootsnap-1.9.1/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
/Users/john/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bootsnap-1.9.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
/Users/john/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bootsnap-1.9.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
/Users/john/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.15/lib/zeitwerk/kernel.rb:26:in `require'
/Users/john/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.15/lib/zeitwerk/loader/helpers.rb:148:in `const_get'
/Users/john/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.15/lib/zeitwerk/loader/helpers.rb:148:in `cget'
```