### PR TITLE
Fix for getting empty date field value

### DIFF
--- a/lib/terrier/scripts/script_field.rb
+++ b/lib/terrier/scripts/script_field.rb
@@ -17,7 +17,7 @@ class ScriptField
     elsif s =~ /\d{4}-\d{2}-\d{2}/
       Time.parse s
     else
-      eval(s).to_time
+      eval(s)&.to_time
     end
   end
 


### PR DESCRIPTION
Result of `eval('')` is `nil`