### PR TITLE
Eliminate contention for authorized_keys file

### DIFF
--- a/lib/tasks/terrier/ssh.rake
+++ b/lib/tasks/terrier/ssh.rake
@@ -3,9 +3,8 @@ require_relative '../../terrier/system/ssh_key_manager'
 namespace :ssh do
 
   desc "Updates the authorized_keys file with the public keys from terrier.tech"
-  task :update_public_keys, [:clyp] => [:environment] do |t, args|
-    clyp = args[:clyp] || ENV['CLYP']
-    SshKeyManager.new(clyp).update_public_keys
+  task :update_public_keys do
+    SshKeyManager.new.update_public_keys
   end
 
 end

--- a/lib/terrier/system/ssh_key_manager.rb
+++ b/lib/terrier/system/ssh_key_manager.rb
@@ -4,29 +4,13 @@ require 'http'
 class SshKeyManager
   include Loggable
 
-  def initialize(clyp)
-    @clyp = clyp
-    @clyp_s = clyp.present? ? "clyp #{clyp}" : 'no clyp'
-
+  def initialize
     @env = Rails.env&.to_s || 'development'
   end
 
   # updates the keys in the authorized_keys file based on the given clyp from terrier.tech
   def update_public_keys
-    info "Updating public keys for #{@clyp_s}"
-
-    # get the keys
-    res = HTTP.get "https://terrier.tech/public_keys.json", params: { clyp: @clyp }
-    raw = JSON.parse res.to_s
-    unless raw['status'] == 'success'
-      ap raw
-      raise "Error getting public keys: #{res['message']}"
-    end
-    new_keys = raw['public_keys'].sort
-    info "Found #{new_keys.count} keys for #{@clyp_s}:"
-    new_keys.each do |key|
-      puts key
-    end
+    info "Updating public keys"
 
     # compute the authorized_keys path
     if @env == 'development'
@@ -39,33 +23,52 @@ class SshKeyManager
       info "Using authorized_keys path: #{file_path}"
     end
 
-    # read existing keys
-    existing_keys = []
-    if File.exist? file_path
-      existing_keys = File.read(file_path).split("\n").compact.map(&:strip).sort
+    File.open(file_path, "r+:US-ASCII") do |file|
+      # lock the file to avoid contention with other apps on the same machine editing this file simultaneously
+      lock = file.flock(File::LOCK_EX | File::LOCK_NB)
+      unless lock
+        info "Another process is already updating keys!"
+        return
+      end
+
+      # get the keys
+      res = HTTP.get "https://terrier.tech/public_keys.json"
+      raw = JSON.parse res.to_s
+      unless raw['status'] == 'success'
+        ap raw
+        raise "Error getting public keys: #{res['message']}"
+      end
+      new_keys = raw['public_keys'].sort
+      info "Found #{new_keys.count} keys"
+      new_keys.each do |key|
+        puts key
+      end
+
+      # read existing keys
+      existing_keys = file.read.split("\n").compact.map(&:strip).sort
       info "#{existing_keys.count} existing keys in #{file_path}"
-    else
-      info "#{file_path} does not exist, no existing keys"
-    end
 
-    # abort if the existing keys are the same as the new ones
-    if existing_keys.join == new_keys.join
-      info "Existing keys are the same as the new ones, nothing to do"
-      return
-    end
+      # abort if the existing keys are the same as the new ones
+      if existing_keys.join == new_keys.join
+        info "Existing keys are the same as the new ones, nothing to do"
+        return
+      end
 
-    # write the existing keys to a backup file
-    if existing_keys.present?
-      backup_path = "#{file_path}_#{Time.new.strftime(TIMESTAMP_FORMAT)}"
-      info "Existing keys are different than the new ones, writing them to #{backup_path}"
-      File.write backup_path, existing_keys.join("\n")
-    else
-      info "No existing keys, nothing to back up"
-    end
+      # write the existing keys to a backup file
+      if existing_keys.present?
+        backup_path = "#{file_path}_#{Time.new.strftime(TIMESTAMP_FORMAT)}"
+        info "Existing keys are different than the new ones, writing them to #{backup_path}"
+        File.write backup_path, existing_keys.join("\n")
+      else
+        info "No existing keys, nothing to back up"
+      end
 
-    # write the new keys
-    info "Writing new keys to #{file_path}"
-    File.write file_path, new_keys.join("\n")
+      # write the new keys
+      info "Writing new keys to #{file_path}"
+      file.pos = 0
+      file.truncate(0)
+      file.write(new_keys.join("\n"))
+    end
   end
 
 end


### PR DESCRIPTION
When both staging and prod are on the same machine (or when multiple clypboard instances are on the same machine), both can end up trying to write to the file at the same time, causing some writes to be lost.

By locking the file, we ensure that only one process will write to the file at a time (and also avoid duplicate requests to terrier.tech).

Also remove the clyp param since terrier.tech doesn't use that param anyway.

cc @ajselvig 