### PR TITLE
Strings: Add param for upcase

### DIFF
--- a/app/assets/javascripts/terrier/strings.coffee
+++ b/app/assets/javascripts/terrier/strings.coffee
@@ -32,30 +32,30 @@ window.leftPad = (s, width) ->
 _upcaseValues = ['cod', 'csr', 'html', 'pdf', 'ach', 'eft', 'wdi', 'wdo']
 _upcaseBlacklist = ['at', 'by', 'to', 'is', 'or', 'of']
 
-# only capitalizes the first character
-window.capitalize = (s) ->
+# capitalizes the first character or the first 2 if conditions allow
+window.capitalize = (s, upcase=true) ->
 	unless s?
 		return ''
-	if (s.length < 3 and _upcaseBlacklist.indexOf(s) < 0) or _upcaseValues.indexOf(s)>-1
+	if upcase and ((s.length < 3 and _upcaseBlacklist.indexOf(s) < 0) or _upcaseValues.indexOf(s)>-1)
 		return s.toUpperCase()
 	s && s[0].toUpperCase() + s.slice(1)
 
-String::capitalize = ->
-	window.capitalize this
+String::capitalize = (upcase) ->
+	window.capitalize this, upcase
 
 # capitalizes every word
-window.titleize = (s) ->
+window.titleize = (s, upcase) ->
 	unless s?
 		return ''
 	s = s.toString()
 	if s == '_state'
 		return s
 	comps = s.split(/[\s_-]/g)
-	capitalized = _.map comps, (c) -> window.capitalize(c)
+	capitalized = _.map comps, (c) -> window.capitalize(c, upcase)
 	capitalized.join ' '
 
-String::titleize = ->
-	window.titleize this
+String::titleize = (upcase) ->
+	window.titleize this, upcase
 
 # converts the string to camel-case
 window.camelize = (s) ->


### PR DESCRIPTION
Whether or not it's safe to capitalize both letters in a two letter word is contextually dependent. I don't think there's a way we can handle this universally. My idea (this PR) is to have the option to bypass two letter word capitalizations in situations where the input is _unlikely_ to require full capitalization (ex: a US state isn't a potential value).

The problem I'm having that makes this necessary is that I'm [creating a clyp value](https://terrier.tech/hub/posts/6a058628-1694-4855-8757-b6bb1c459e86) where one of the values in the array is getting capitalized when it shouldn't. I want to make sure to match the previous value ("No Service Due") for reporting purposes.

![CleanShot 2024-12-10 at 12 28 12](https://github.com/user-attachments/assets/4d98105c-74f6-4728-bf40-5caedf249e2d)
