### PR TITLE
Site Tops: Fix volume for shared servers

### DIFF
--- a/lib/terrier/system/top.rb
+++ b/lib/terrier/system/top.rb
@@ -28,7 +28,11 @@ module Top
       if line.ends_with?('/') # this is the root partition
         data[:disk] = Top.parse_disk_line line
       elsif line.index(/\s\/mnt\//) || line.index(/\/System\/Volumes\/Data$/) # /System/Volumes/Data for development
-        data[:volume] = Top.parse_disk_line line
+        if defined?(CLYP) && line.index(CLYP) # prefer vols with clyp name
+          data[:volume] = Top.parse_disk_line line
+        else
+          data[:volume] ||= Top.parse_disk_line line
+        end
       end
     end
 


### PR DESCRIPTION
No post. Shared servers tend to list the wrong volume on the clyps page because they just use whichever mounted volume is listed last by `df -m`

![CleanShot 2025-04-01 at 09 44 33@2x](https://github.com/user-attachments/assets/a3aa27f8-76f1-43d3-b0df-bb6f3e88ee96)

This works as long as we keep putting the clyp name in external volumes' names:

![CleanShot 2025-04-01 at 09 50 08@2x](https://github.com/user-attachments/assets/e694aec1-b66f-4ad5-af02-11ea8c4bb449)
