### PR TITLE
Make script editor work with coffeescript 2

### DIFF
--- a/app/assets/javascripts/terrier/scripts.coffee
+++ b/app/assets/javascripts/terrier/scripts.coffee
@@ -1041,20 +1041,21 @@ class Workspace
 		@scriptMap = {}
 		@itemMap = {}
 
-		@layout.registerComponent 'editor', (container, state) =>
+		parent = @
+		@layout.registerComponent 'editor', (container, state) ->
 			if state?.id?.length
 				$.get(
 					"/scripts/#{state.id}.json"
 					(res) =>
 						if res.status == 'success'
-							@scriptMap[res.script.id] = res.script
-							@itemMap[res.script.id] = container
-							editor = new Editor(res.script, container, @constants)
+							parent.scriptMap[res.script.id] = res.script
+							parent.itemMap[res.script.id] = container
+							editor = new Editor(res.script, container, parent.constants)
 						else
 							alert res.message
 				)
 			else # new script
-				editor = new Editor({title: 'New Script'}, container, @constants)
+				editor = new Editor({title: 'New Script'}, container, parent.constants)
 
 		@layout.on 'itemDestroyed', (evt) =>
 			id = evt.config?.componentState?.id


### PR DESCRIPTION
This request allows the script editor to work on coffeescript 2. The problem was that due to an arrow function being used as a constructor, requiring the use of a regular function and manually binding `this`.
