### PR TITLE
TinyTemplate Args: Set null to undefined explicitly

### DIFF
--- a/app/assets/javascripts/terrier/tiny-template.coffee
+++ b/app/assets/javascripts/terrier/tiny-template.coffee
@@ -95,6 +95,8 @@ appendTag = (tag, selector, attrs, func) ->
 window.tinyTemplate = (root) ->
 	(args...) ->
 		_context = {content: ''}
+		# Replace nulls with undefined so arg defaults are used (if defined)
+		args = args.map (arg) -> if arg == null then undefined else arg
 		root(args...)
 		_context.content
 


### PR DESCRIPTION
Coffeescript 2 more closely follows ES6, so the JS it compiles to considers nulls to be valid arguments instead of replacing them like Coffeescript 1 did. We can get the previous behavior by replacing null with undefined explicitly.