### PR TITLE
Modals: don't always take up full page height and smoother stack transitions

### DIFF
--- a/app/assets/stylesheets/terrier/tt-modal.scss
+++ b/app/assets/stylesheets/terrier/tt-modal.scss
@@ -45,7 +45,14 @@
 .tt-modal-stack .modal-part {
 	@include tt-rounded-corners;
 	@include tt-box-shadow;
-	@include tt-absolute-fill;
+
+	position: absolute;
+	left: 0;
+	right: 0;
+	top: 50%;
+	max-height: 100%;
+	min-height: 50%;
+
 	margin: 0 auto;
 	background: var(--tt-panel-background);
 	display: flex;
@@ -136,21 +143,30 @@
 		bottom: unset;
 	}
 
-	&:last-child {
-		transform: scale(0);
+	transition: transform 0.2s ease, opacity 0.2s ease;
+
+	// offset up 50% of height to center vertically
+	transform: translate(20%, -50%);
+	opacity: 0;
+
+	// lower modals in the stack are slightly blurred and can't be interacted with
+	&:not(:last-child) {
+		filter: blur(var(--tt-blur-width, 3px));
+		pointer-events: none;
 	}
 
-	transition: transform 0.2s ease;
-
-	// fan out the models based on their position in the stack
+	// fan out the modals based on their position in the stack
 	&.show {
 		&:last-child {
-			transform: scale(1);
+			transform: translate(0, -50%);
+			opacity: 1;
 		}
 
+		// offset slightly left and smaller
 		@for $i from 1 through 6 {
 			&:nth-last-child(#{$i + 1}) {
-				transform: translate(calc(-#{$i}*var(--tt-pad)*3), 0) scale(100%-$i*4%);
+				transform: translate(calc(-#{$i}*var(--tt-pad)*3), -50%) scale(100%-$i*4%);
+				opacity: 1;
 			}
 		}
 	}

--- a/app/frontend/terrier/app.ts
+++ b/app/frontend/terrier/app.ts
@@ -89,7 +89,6 @@ export abstract class TerrierApp<TState> extends TerrierPart<TState> {
     ): ModalType {
         const modalStack = this.overlayPart.getOrCreateLayer(ModalStackPart, {}, 'modal')
         const modal = modalStack.pushModal(constructor, state)
-        modalStack.dirty()
         return modal as ModalType
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2254,9 +2254,9 @@
       }
     },
     "node_modules/tuff-core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tuff-core/-/tuff-core-2.2.0.tgz",
-      "integrity": "sha512-pdnaUSVyVzoj2vViIbjk9sCvhZqt+e8OmxsupgwqApZM+UVwnGCMXbof/vOyfqO6rI19bxX8yaaseAz2LCdvMg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tuff-core/-/tuff-core-2.2.2.tgz",
+      "integrity": "sha512-qvBGJKuTRzKzvsiTFqRYkfg4omn0NMiQyeFQ0I/ILfPO4TeNMMewBJt7zkwGdr7oU4lfY7Vg6RG1er2SRj9H5A==",
       "license": "MIT",
       "dependencies": {
         "path-to-regexp": "^6.3.0",

--- a/test/dummy/app/frontend/demo/demo-parts.ts
+++ b/test/dummy/app/frontend/demo/demo-parts.ts
@@ -17,6 +17,7 @@ import Messages from "tuff-core/messages"
 import { NoState, PartTag } from "tuff-core/parts"
 import Strings from "tuff-core/strings"
 import Time from "tuff-core/time"
+import { faker } from '@faker-js/faker'
 
 const log = new Logger("Demo Parts")
 
@@ -176,6 +177,8 @@ class Panel extends PanelPart<NoState> {
 
 class Modal extends ModalPart<NoState> {
 
+    private paragraphs: string[] = []
+
     async init() {
         this.setTitle("Modal Header")
 
@@ -195,10 +198,19 @@ class Modal extends ModalPart<NoState> {
             classes: ['secondary'],
             click: {key: modalPopKey}
         }, "secondary")
+
+        const count = Math.ceil(Math.random() * 4)
+        for (let i = 0; i < count; i++) {
+            this.paragraphs.push(faker.lorem.paragraphs({ min: 3, max: 15 }))
+        }
     }
 
     renderContent(parent: PartTag): void {
-        parent.p({text: "Modal Content"})
+        parent.div('.tt-flex.padded.column.gap', div => {
+            for (const paragraph of this.paragraphs) {
+                div.p().text(paragraph)
+            }
+        })
     }
 
 }

--- a/test/dummy/package-lock.json
+++ b/test/dummy/package-lock.json
@@ -6,6 +6,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@faker-js/faker": "^9.9.0",
         "tuff-core": "latest"
       },
       "devDependencies": {
@@ -402,6 +403,22 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
+      "integrity": "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/test/dummy/package-lock.json
+++ b/test/dummy/package-lock.json
@@ -1301,9 +1301,9 @@
       }
     },
     "node_modules/tuff-core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tuff-core/-/tuff-core-2.2.0.tgz",
-      "integrity": "sha512-pdnaUSVyVzoj2vViIbjk9sCvhZqt+e8OmxsupgwqApZM+UVwnGCMXbof/vOyfqO6rI19bxX8yaaseAz2LCdvMg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tuff-core/-/tuff-core-2.2.2.tgz",
+      "integrity": "sha512-qvBGJKuTRzKzvsiTFqRYkfg4omn0NMiQyeFQ0I/ILfPO4TeNMMewBJt7zkwGdr7oU4lfY7Vg6RG1er2SRj9H5A==",
       "license": "MIT",
       "dependencies": {
         "path-to-regexp": "^6.3.0",

--- a/test/dummy/package.json
+++ b/test/dummy/package.json
@@ -9,6 +9,7 @@
     "vite-plugin-ruby": "^5.1.1"
   },
   "dependencies": {
+    "@faker-js/faker": "^9.9.0",
     "tuff-core": "latest"
   }
 }


### PR DESCRIPTION
It always kind of annoyed me that terrier platform modals always take the full height, even for just a single line of text or 1 or 2 form elements. This change makes them dynamically adjust between 50% and 100% of the page height. I also made some improvements to the stack transition animations since before they could be kinda wonky.

https://github.com/user-attachments/assets/47a80ee3-4f74-415a-9133-31732de45d01

