### PR TITLE
update type generation for enum dependencies

### DIFF
--- a/lib/terrier/frontend/model_generator.rb
+++ b/lib/terrier/frontend/model_generator.rb
@@ -178,6 +178,77 @@ class ModelGenerator < BaseGenerator
     models
   end
 
+  def build_typescript_model_type(model_name, model, is_unpersisted = false)
+    type_str = "#{model_name} = { "
+    model_class = model[:model_class]
+
+    fields = []
+    columns = model[:columns]
+
+    enum_dependency_strings = []
+    if model_class.enum_dependencies
+      model_class.enum_dependencies.each do |dep_field, deps|
+        used_enum_values = []
+        deps.each do |enum_val, required_field|
+          enum_type_str = <<~TS
+            ({#{dep_field}: '#{enum_val}'; #{required_field}: #{typescript_type(model_class.columns_hash[required_field.to_s], model_class)}} 
+          TS
+
+          remaining_enum_values = model[:enum_fields][dep_field] - [enum_val.to_s]
+
+          enum_type_str += <<~TS 
+            | {#{dep_field}: #{remaining_enum_values.map { |v| "'#{v}'" }.join(' | ')}; #{typescript_field(model_class.columns_hash[required_field.to_s], model_class)}})
+          TS
+
+          enum_dependency_strings.push enum_type_str.strip
+
+          columns.delete dep_field
+          columns.delete required_field
+        end
+      end
+    end
+
+    # columns
+    columns.each do |col|
+      next if model[:attachments].include?(col.name.to_sym)
+      fields.push typescript_field(col, model_class, model[:enum_fields][col.name.to_sym], is_unpersisted)
+    end
+
+    # reflections (associations)
+    model[:reflections].each do |ref_name, ref|
+      ref_type = compute_ref_type(ref)
+      next unless ref_type
+      if is_unpersisted && ref_type.include?('[]')
+        fk = ref.options[:foreign_key].presence || "#{model_name.tableize.singularize}_id"
+        ref_type = "OptionalProps<Unpersisted#{ref_type.gsub('[]', '')},'#{fk}'>[]"
+      end
+      fields.push "#{ref_name}?: #{ref_type}"
+    end
+
+    # attachments
+    model[:attachments].each do |attachment|
+      fields.push "#{attachment}?: File"
+    end
+
+    type_str += fields.join(', ') + " }"
+    if enum_dependency_strings.present?
+      type_str += " & #{enum_dependency_strings.join(' & ')}"
+    end
+    type_str
+  end
+
+  def typescript_field(col, model_class, enum_fields = nil, is_unpersisted = false)
+    str = col.name
+
+    if is_unpersisted
+      str += col.null || %w[id created_at created_by_name updated_at _state].include?(col.name) ? '?' : ''
+    else
+      str += col.null ? '?' : ''
+    end
+    str += ': ' + typescript_type(col, model_class, enum_fields)
+    str
+  end
+
   # @return [String] the typescript type associated with the given column type
   def typescript_type(col, model_class, enum_fields = nil)
     if model_class.respond_to?(:embedded_fields)

--- a/lib/terrier/frontend/models.ts.erb
+++ b/lib/terrier/frontend/models.ts.erb
@@ -7,39 +7,9 @@
 <% models.keys.sort.each do |model_name| %>
   <% model = models[model_name] %>
 
-  export type <%= model_name %> = {
-    <% model[:columns].each do |col| -%>
-      <% next if model[:attachments].include?(col.name.to_sym) -%>
-      <%= col.name %><%= col.null ? '?' : '' %>: <%= typescript_type(col, model[:model_class], model[:enum_fields][col.name.to_sym]) %>
-    <% end -%>
-    <% model[:reflections].each do |ref_name, ref| -%>
-      <% ref_type = compute_ref_type(ref) -%>
-      <% next unless ref_type -%>
-      <%= ref_name %> ? : <%= ref_type %>
-    <% end -%>
-    <% model[:attachments].each do |attachment| -%>
-      <%= attachment %> ? : File
-    <% end -%>
-  }
-
-  export type Unpersisted<%= model_name %> = {
-    <% model[:columns].each do |col| -%>
-      <% next if model[:attachments].include?(col.name.to_sym) -%>
-      <%= col.name %><%= col.null || unpersisted_columns.include?(col.name) ? '?' : '' %>: <%= typescript_type(col, model[:model_class], model[:enum_fields][col.name.to_sym]) %>
-    <% end -%>
-    <% model[:reflections].each do |ref_name, ref| -%>
-      <% ref_type = compute_ref_type(ref) -%>
-      <% next unless ref_type -%>
-      <% if ref_type.include?('[]') -%>
-        <% fk = ref.options[:foreign_key].presence || "#{model_name.tableize.singularize}_id" -%>
-        <% ref_type = "OptionalProps<Unpersisted#{ref_type.gsub('[]', '')},'#{fk}'>[]" -%>
-      <% end -%>
-      <%= ref_name %>?: <%= ref_type %>
-    <% end -%>
-    <% model[:attachments].each do |attachment| -%>
-      <%= attachment %>?: File
-    <% end -%>
-  }
+  export type <%= build_typescript_model_type(model_name, model) %>
+  
+  export type Unpersisted<%= build_typescript_model_type(model_name, model, true) %>
 
   <% if model[:enum_fields].present? -%>
     export const <%= model_name %>EnumFields = {


### PR DESCRIPTION
I'd like to minimize the extent to which typescript yells at us for doing things that actually make sense. In the following case, we should know that `num_periods` should be populated if `recurring_type` is set to 'periodic:'

<img width="1150" height="340" alt="CleanShot 2025-08-26 at 14 06 56@2x" src="https://github.com/user-attachments/assets/06603627-c2bc-4f68-9c00-e97874b9d02b" />

The intent here is to add an `enum_dependencies` class method to ApplicationRecord that can specify required fields depending on the value of an enum column on the record. The changes in terrier-engine will adjust the generation of models.ts to check for enum dependencies.

With 
