### PR TITLE
Save table sorting in local storage

### DIFF
--- a/app/assets/javascripts/terrier/tables.coffee
+++ b/app/assets/javascripts/terrier/tables.coffee
@@ -8,12 +8,19 @@ _numberRegex = /^(?=.)([+-]?([0-9]*)(\.([0-9]+))?)$/g # pos/neg integer/float
 
 window.tables.initSortable = (ui = $(document), col = null, dir = null) ->
 	params = getUrlParams()
+	path = window.location.pathname
+	table = ui.find 'table.sortable'
+	key = table.data 'sortable-persistence-key'
+	[storedCol, storedDir] = if key?
+		window.localStorage.getItem("sortable:#{key}:#{path}")?.split(',') ? [null, null]
+	else
+		[null, null]
 
-	col = col ? params.sortable_col
-	dir = dir ? params.sortable_dir
+	col = col ? params.sortable_col ? storedCol 
+	dir = dir ? params.sortable_dir ? storedDir
 	
 	return unless col && dir
-	ui.find("table.sortable th a[data-column=#{col}]").each (_, link) ->
+	table.find("th a[data-column=#{col}]").each (_, link) ->
 		window.tables.sortByColLink($(link), col, dir)
 
 # computes the sorting value using a) input values, b) data-column attributes, or c) the text of the cell
@@ -51,6 +58,11 @@ _blanksLast = (s) ->
 window.tables.sortByColLink = (link, col = null, dir = null) ->
 	window.setLinkLoading? link
 	table = link.parents 'table'
+
+	# Save sort preferences
+	path = window.location.pathname
+	key = table.data 'sortable-persistence-key'
+	window.localStorage.setItem("sortable:#{key}:#{path}", [col, dir].join(',')) if key?
 
 	# need to let the loading animation start
 	{ promise, resolve } = Promise.withResolvers()

--- a/app/assets/javascripts/terrier/tables.coffee
+++ b/app/assets/javascripts/terrier/tables.coffee
@@ -8,11 +8,13 @@ _numberRegex = /^(?=.)([+-]?([0-9]*)(\.([0-9]+))?)$/g # pos/neg integer/float
 
 window.tables.initSortable = (ui = $(document), col = null, dir = null) ->
 	params = getUrlParams()
-	col = if col then col else params.sortable_col
-	dir = if dir then dir else params.sortable_dir
-	if col && dir
-		ui.find("table.sortable th a[data-column=#{col}]").each (_, link) ->
-			window.tables.sortByColLink($(link), col, dir)
+
+	col = col ? params.sortable_col
+	dir = dir ? params.sortable_dir
+	
+	return unless col && dir
+	ui.find("table.sortable th a[data-column=#{col}]").each (_, link) ->
+		window.tables.sortByColLink($(link), col, dir)
 
 # computes the sorting value using a) input values, b) data-column attributes, or c) the text of the cell
 _computeCellValue = (cell) ->
@@ -32,7 +34,7 @@ _computeCellValue = (cell) ->
 
 	# return float if this value is numeric (starts with numbers or decimal point)
 	floatVal = parseFloat(val)
-	if !_.isNaN(floatVal) and val.toString().match(_numberRegex)
+	if !_.isNaN(floatVal) && val.toString().match(_numberRegex)
 		return floatVal
 
 	# use string data value or c) use raw text
@@ -47,53 +49,54 @@ _blanksLast = (s) ->
 		Number.MAX_SAFE_INTEGER.toString()
 
 window.tables.sortByColLink = (link, col = null, dir = null) ->
-	if window.setLinkLoading?
-		window.setLinkLoading link
+	window.setLinkLoading? link
 	table = link.parents 'table'
-	setTimeout(# need to let the loading animation start
-		->
-			unless col
-				col = link.data 'column'
-				urls.replaceParam 'sortable_col', col
-			unless dir
-				descOnly = table.hasClass 'desc-only'
-				dir = if descOnly or link.hasClass('asc')
-					'desc'
-				else
-					'asc'
-				urls.replaceParam 'sortable_dir', dir
 
-			table.find('th a').removeClass('asc').removeClass('desc')
-			link.addClass dir
+	# need to let the loading animation start
+	{ promise, resolve } = Promise.withResolvers()
+	setTimeout(resolve, 5)
+	await promise
+	
+	unless col
+		col = link.data 'column'
+		urls.replaceParam 'sortable_col', col
+	unless dir
+		descOnly = table.hasClass 'desc-only'
+		dir = if descOnly or link.hasClass('asc')
+			'desc'
+		else
+			'asc'
+		urls.replaceParam 'sortable_dir', dir
 
-			# sort the rows
-			t = performance.now()
-			rows = table.find('tbody tr').not('.always-top')
-			rows.sort (a, b) ->
-				aCol = $(a).find(".col-#{col}, .column-#{col}")
-				aVal = _computeCellValue aCol
-				bCol = $(b).find(".col-#{col}, .column-#{col}")
-				bVal = _computeCellValue bCol
-				comp = if aVal > bVal
-					1
-				else
-					-1
-				if dir == 'desc'
-					return -comp
-				comp
-			puts "Sorted rows in #{(performance.now() - t).toFixed(2)} ms"
+	table.find('th a').removeClass('asc').removeClass('desc')
+	link.addClass dir
 
-			t = performance.now()
-			alwaysTopRow = table.find('tr.always-top')
-			if alwaysTopRow.length > 0
-				table.find('tbody').prepend(alwaysTopRow)
-			rows.detach().appendTo table.find('tbody')
-			table.find('tbody tr.total').detach().appendTo table.find('tbody')
-			puts "Re-attached rows in #{(performance.now() - t).toFixed(2)} ms"
-			if window.unsetLinkLoading?
-				window.unsetLinkLoading link
-		5
-	)
+	# sort the rows
+	t = performance.now()
+	rows = table.find('tbody tr').not('.always-top')
+	rows.sort (a, b) ->
+		aCol = $(a).find(".col-#{col}, .column-#{col}")
+		aVal = _computeCellValue aCol
+		bCol = $(b).find(".col-#{col}, .column-#{col}")
+		bVal = _computeCellValue bCol
+		comp = if aVal > bVal
+			1
+		else
+			-1
+		if dir == 'desc'
+			return -comp
+		comp
+	console.log "Sorted rows in #{(performance.now() - t).toFixed(2)} ms"
+
+	t = performance.now()
+	alwaysTopRow = table.find('tr.always-top')
+	if alwaysTopRow.length > 0
+		table.find('tbody').prepend(alwaysTopRow)
+	rows.detach().appendTo table.find('tbody')
+	table.find('tbody tr.total').detach().appendTo table.find('tbody')
+	console.log "Re-attached rows in #{(performance.now() - t).toFixed(2)} ms"
+	if window.unsetLinkLoading?
+		window.unsetLinkLoading link
 
 $(document).on 'click', 'table.sortable th a[data-column]', (evt) ->
 	evt.stopPropagation()


### PR DESCRIPTION
For [this Hub post](https://terrier.tech/hub/posts/924b7ce5-e8bd-41f3-8d56-90d908956b7a).

This pull request implements saving the sort order for a sortable table to the
browser's local storage, and restoring it when the sort order changes.