### PR TITLE
Isolate script executions

### DIFF
--- a/lib/terrier/scripts/script_executor.rb
+++ b/lib/terrier/scripts/script_executor.rb
@@ -96,7 +96,7 @@ class ScriptExecutor
     escaped_body = body.gsub('\"', '"')
     filename = "script"
     filename += "<#{@script.title}>" if @script&.title.present?
-    eval(escaped_body, binding, filename, 1)
+    instance_eval(escaped_body, filename, 1)
   end
 
   def write_raw(type, body, extra={})


### PR DESCRIPTION
https://terrier.tech/hub/posts/9ca58935-f935-49ac-b5b1-d0d472e52726

We want to make sure method definitions are per-object, which we can do with `instance_eval`. That method redefines `self` as a singleton (`ScriptExecutor`) class, which can be mutated without affecting subsequent executions.